### PR TITLE
Use AndroidHighResolutionTimer for elapsed time

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AndroidHighResolutionTimer.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AndroidHighResolutionTimer.java
@@ -1,0 +1,24 @@
+package org.eclipse.paho.android.service;
+
+import android.os.Build;
+import android.os.SystemClock;
+
+import org.eclipse.paho.client.mqttv3.internal.HighResolutionTimer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An android {@code HighResolutionTimer} implementation that includes the time spent asleep.
+ */
+public class AndroidHighResolutionTimer implements HighResolutionTimer {
+    @Override
+    public long nanoTime() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return SystemClock.elapsedRealtimeNanos();
+        } else {
+            // Use the old currentTimeMillis implementation in API levels that don't support elapsedRealtimeNanos
+            // See: https://github.com/eclipse/paho.mqtt.java/issues/278
+            return TimeUnit.NANOSECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -249,7 +249,8 @@ class MqttConnection implements MqttCallbackExtended {
             // if myClient is null, then create a new connection
             else {
                 alarmPingSender = new AlarmPingSender(service);
-                myClient = new MqttAsyncClient(serverURI, clientId, persistence, alarmPingSender);
+                myClient = new MqttAsyncClient(serverURI, clientId, persistence, alarmPingSender, null,
+						new AndroidHighResolutionTimer());
                 myClient.setCallback(this);
 
                 service.traceDebug(TAG, "Do Real connect!");


### PR DESCRIPTION
https://github.com/eclipse/paho.mqtt.android/pull/425

This timer uses SystemClock.elapsedRealtimeNanos to calculate the high
resolution timing value, which advances time when the device is asleep.

Fixes a bug introduced by the paho.mqtt.java library when it was changed
to track elapsed time using System.nanoTime. However, on android,
nanoTime does not advance when the device is in a deep sleep. As a
result, pings may not be sent frequently enough, resulting in client
disconnects.

See:
https://github.com/eclipse/paho.mqtt.java/issues/278
https://github.com/eclipse/paho.mqtt.java/issues/774

Signed-off-by: Dustin Thomson <dthomson@51systems.com>