### PR TITLE
Subscribe should not return null

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -962,7 +962,7 @@ public class MqttAndroidClient extends BroadcastReceiver implements IMqttAsyncCl
         String activityToken = storeToken(token);
         mqttService.subscribe(clientHandle, topicFilters, qos, null, activityToken, messageListeners);
 
-        return null;
+        return token;
     }
 
     /**

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -588,7 +588,7 @@ class MqttConnection implements MqttCallbackExtended {
         if ((myClient != null) && (myClient.isConnected())) {
             IMqttActionListener listener = new MqttConnectionListener(resultBundle);
             try {
-                myClient.subscribe(topicFilters, qos, messageListeners);
+                myClient.subscribe(topicFilters, qos, null, listener,messageListeners);
             } catch (Exception e) {
                 handleException(resultBundle, e);
             }


### PR DESCRIPTION
Always returning null breaks the contract set in the function signature
and documentation.

This affects all subscribes that receive `IMqttMessageListener` as parameter.

Should pass IMqttActionListener on subscribe (#262)

 On subscribe, a failure would be reported but onSuccess would never be
called. The reason was not passing the IMqttActionListener forward to
MqttClient.

https://github.com/eclipse/paho.mqtt.android/pull/383