### PR TITLE
Support message buffering before initial connect 

### DIFF
--- a/serviceLibrary/src/main/java/org/eclipse/paho/android/service/MqttService.java
+++ b/serviceLibrary/src/main/java/org/eclipse/paho/android/service/MqttService.java
@@ -284,8 +284,10 @@ public class MqttService extends Service implements MqttTraceHandler {
      * @param persistence specifies the persistence layer to be used with this client
      * @return a string to be used by the Activity as a "handle" for this
      * MqttConnection
-     */
-    public String getClient(String serverURI, String clientId, String contextId, MqttClientPersistence persistence) {
+     * @throws MqttException thrown if failed to create client
+   */
+    public String getClient(String serverURI, String clientId, String contextId,
+                          MqttClientPersistence persistence) throws MqttException {
         String clientHandle = serverURI + ":" + clientId + ":" + contextId;
         if (!connections.containsKey(clientHandle)) {
             MqttConnection client = new MqttConnection(this, serverURI, clientId, persistence, clientHandle);
@@ -339,7 +341,7 @@ public class MqttService extends Service implements MqttTraceHandler {
     public void disconnect(String clientHandle, String invocationContext, String activityToken) {
         MqttConnection client = getConnection(clientHandle);
         client.disconnect(invocationContext, activityToken);
-        connections.remove(clientHandle);
+
 
 
         // the activity has finished using us, so we can stop the service
@@ -359,7 +361,7 @@ public class MqttService extends Service implements MqttTraceHandler {
     public void disconnect(String clientHandle, long quiesceTimeout, String invocationContext, String activityToken) {
         MqttConnection client = getConnection(clientHandle);
         client.disconnect(quiesceTimeout, invocationContext, activityToken);
-        connections.remove(clientHandle);
+
 
         // the activity has finished using us, so we can stop the service
         // the activities are bound with BIND_AUTO_CREATE, so the service will


### PR DESCRIPTION
This change will enable offline buffering even if initial connection has never been established yet.

I've changed MqttAndoidClient, MqttService, MqttConnection in order to instantiate these instances before connection get established.

https://github.com/eclipse/paho.mqtt.android/pull/198