### PR TITLE
Move to Work Manager.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ println "Gradle uses Java ${Jvm.current()}"
 ext {
     compileSdkVersion = 31
     room_version = "2.4.2"
+    worker_version = "2.7.1"
 }
 
 allprojects {

--- a/serviceLibrary/build.gradle
+++ b/serviceLibrary/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation "com.github.AppDevNext.Logcat:LogcatCoreLib:2.9.5"
 
     implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.work:work-runtime-ktx:$worker_version"
     kapt "androidx.room:room-compiler:$room_version"
 
     androidTestImplementation "androidx.test.ext:junit:1.1.3"

--- a/serviceLibrary/src/main/AndroidManifest.xml
+++ b/serviceLibrary/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application>

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -1,158 +1,85 @@
 package info.mqtt.android.service.ping
 
-import android.annotation.SuppressLint
-import android.app.AlarmManager
-import android.app.PendingIntent
-import android.app.Service
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
-import android.os.Build
-import android.os.PowerManager
-import android.os.SystemClock
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
 import info.mqtt.android.service.MqttService
-import info.mqtt.android.service.MqttServiceConstants
-import kotlinx.coroutines.*
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.eclipse.paho.client.mqttv3.IMqttActionListener
 import org.eclipse.paho.client.mqttv3.IMqttToken
-import org.eclipse.paho.client.mqttv3.MqttException
 import org.eclipse.paho.client.mqttv3.MqttPingSender
 import org.eclipse.paho.client.mqttv3.internal.ClientComms
 import timber.log.Timber
-import kotlin.system.measureTimeMillis
 
 /**
  * Default ping sender implementation on Android. It is based on AlarmManager.
  *
- * This class implements the [MqttPingSender] pinger interface
+ * <p>This class implements the {@link MqttPingSender} pinger interface
  * allowing applications to send ping packet to server every keep alive interval.
+ * </p>
  *
  * @see MqttPingSender
  */
-internal class AlarmPingSender(val service: MqttService) : MqttPingSender {
-    private var clientComms: ClientComms? = null
-    private var alarmReceiver: BroadcastReceiver? = null
-    private var pendingIntent: PendingIntent? = null
+class AlarmPingSender(val service: MqttService) : MqttPingSender {
 
-    private val pendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-    } else {
-        PendingIntent.FLAG_UPDATE_CURRENT
+    private var comms: ClientComms? = null
+    private val workManager = WorkManager.getInstance(service)
+
+    companion object {
+        // Identifier for Intents, log messages, etc..
+        const val TAG = "AlarmPingSender"
+        const val PING_JOB = "PING_JOB"
     }
 
-    @Volatile
-    private var hasStarted = false
-
-    override fun init(comms: ClientComms) {
-        this.clientComms = comms
-        alarmReceiver = AlarmReceiver()
+    override fun init(comms: ClientComms?) {
+        this.comms = comms
     }
 
     override fun start() {
-        val action = MqttServiceConstants.PING_SENDER + clientComms!!.client.clientId
-        Timber.d("Register AlarmReceiver to MqttService$action")
-        service.registerReceiver(alarmReceiver, IntentFilter(action))
-        pendingIntent = PendingIntent.getBroadcast(service, 0, Intent(action), pendingIntentFlags)
-        schedule(clientComms!!.keepAlive)
-        hasStarted = true
+        comms?.let { clientComms ->
+            schedule(clientComms.keepAlive)
+        }
     }
 
     override fun stop() {
-        Timber.d("Unregister AlarmReceiver to MqttService ${clientComms!!.client.clientId}")
-        if (hasStarted) {
-            if (pendingIntent != null) {
-                // Cancel Alarm.
-                val alarmManager = service.getSystemService(Service.ALARM_SERVICE) as AlarmManager
-                alarmManager.cancel(pendingIntent)
-            }
-            hasStarted = false
-            try {
-                service.unregisterReceiver(alarmReceiver)
-            } catch (e: IllegalArgumentException) {
-                //Ignore unregister errors.
-            }
-        }
+        workManager.cancelUniqueWork(PING_JOB)
     }
 
     override fun schedule(delayInMilliseconds: Long) {
-        val nextAlarmInMilliseconds = SystemClock.elapsedRealtime() + delayInMilliseconds
-        Timber.d("Schedule next alarm at $nextAlarmInMilliseconds ms")
-        val alarmManager = service.getSystemService(Service.ALARM_SERVICE) as AlarmManager
-        if (Build.VERSION.SDK_INT >= 23) {
-            // In SDK 23 and above, dosing will prevent setExact, setExactAndAllowWhileIdle will force
-            // the device to run this task whilst dosing.
-            Timber.d("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")
-            alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, pendingIntent)
-        } else
-            Timber.d("Alarm schedule using setExact, delay: $delayInMilliseconds")
-        alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, pendingIntent)
+        Timber.d("Schedule next alarm at " + System.currentTimeMillis() + delayInMilliseconds)
+        workManager.enqueueUniqueWork(
+            PING_JOB,
+            ExistingWorkPolicy.REPLACE,
+            OneTimeWorkRequest
+                .Builder(PingWorker::class.java)
+                .setInitialDelay(delayInMilliseconds, TimeUnit.MILLISECONDS)
+                .build()
+        )
     }
 
-    fun backgroundExecute(comms: ClientComms?): Boolean {
-        var success = false
-        val token: IMqttToken? = comms?.checkForActivity(object : IMqttActionListener {
-            override fun onSuccess(asyncActionToken: IMqttToken) {
-                success = true
-            }
-
-            override fun onFailure(asyncActionToken: IMqttToken?, exception: Throwable?) {
-                Timber.d("Ping task : Failed.")
-                success = false
-            }
-        })
-        try {
-            if (token != null) {
-                token.waitForCompletion()
-            } else {
-                Timber.d("Ping background : Ping command was not sent by the client.")
-            }
-        } catch (e: MqttException) {
-            Timber.d("Ping background : Ignore MQTT exception : ${e.message}")
-        } catch (ex: Exception) {
-            Timber.d("Ping background : Ignore unknown exception : ${ex.message}")
-        }
-        return success
-    }
-
-    /*
-     * This class sends PingReq packet to MQTT broker
-     */
-    internal inner class AlarmReceiver : BroadcastReceiver() {
-        private val wakeLockTag = MqttServiceConstants.PING_WAKELOCK + clientComms!!.client.clientId
-
-        @SuppressLint("Wakelock")
-        override fun onReceive(context: Context, intent: Intent) {
-            // According to the docs, "Alarm Manager holds a CPU wake lock as
-            // long as the alarm receiver's onReceive() method is executing.
-            // This guarantees that the phone will not sleep until you have
-            // finished handling the broadcast.", but this class still get
-            // a wake lock to wait for ping finished.
-            val pm = service.getSystemService(Service.POWER_SERVICE) as PowerManager
-            val wakelock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, wakeLockTag)
-            wakelock.acquire(TIMEOUT)
-
-            // without blocking the main thread
-            CoroutineScope(Dispatchers.IO).launch {
-                measureTimeMillis {
-                    @Suppress("BlockingMethodInNonBlockingContext")
-                    val response = CoroutineScope(Dispatchers.IO).async {
-                        return@async backgroundExecute(clientComms)
-                    }.await()
-                    Timber.d("Request done $response")
-
-                    if (wakelock.isHeld) {
-                        wakelock.release()
+    inner class PingWorker(context: Context, workerParams: WorkerParameters) :
+        CoroutineWorker(context, workerParams) {
+        override suspend fun doWork(): Result =
+            suspendCancellableCoroutine { continuation ->
+                Timber.d(TAG, "Sending Ping at: ${System.currentTimeMillis()}")
+                comms?.checkForActivity(object : IMqttActionListener{
+                    override fun onSuccess(asyncActionToken: IMqttToken?) {
+                        Timber.d(TAG, "Success.")
+                        continuation.resume(Result.success())
                     }
-                }.also {
-                    Timber.d("Completed in $it ms")
+
+                    override fun onFailure(asyncActionToken: IMqttToken?, exception: Throwable?) {
+                        Timber.d(TAG, "Failure.")
+                        continuation.resume(Result.failure())
+                    }
+                }) ?: kotlin.run {
+                    continuation.resume(Result.failure())
                 }
             }
-        }
     }
-
-    companion object {
-        private const val TIMEOUT = 10 * 60 * 1000L // 10 minutes
-    }
-
 }


### PR DESCRIPTION
Fixes Android 12, "SCHEDULE_EXACT_ALARM permission revoked by user" crash. Issue: https://github.com/hannesa2/paho.mqtt.android/issues/290

Library is using "AlarmService to fire broadcasts at an exact time" for pinging server.

API 31 onwards, exact alarm scheduling is a permission that can be manually revoked by user. Because of this we are see above crash.

Implementation:
With workmanager's, one time worker with initial delay constraint, same use-case can be handled without the need of said permission.