### PR TITLE
[fix]fix persistence bug

### DIFF
--- a/extendedSample/src/main/java/info/mqtt/android/extsample/utils/ConnectionUtils.kt
+++ b/extendedSample/src/main/java/info/mqtt/android/extsample/utils/ConnectionUtils.kt
@@ -54,7 +54,7 @@ fun Connection.toConnectionEntity(): ConnectionEntity = ConnectionEntity(
     connectionOptions.connectionTimeout,
     connectionOptions.keepAliveInterval,
     connectionOptions.userName,
-    connectionOptions.password?.toString(),
+    String(connectionOptions.password?:CharArray(0)),
     connectionOptions.isCleanSession.toInt(),
     connectionOptions.willDestination,
     connectionOptions.willMessage?.payload.toString(), // message


### PR DESCRIPTION
In the Demo extendedSample, saved error password field when persistence to Sqlite.

It lead to a MqttSecurityException (MqttSecurityException Not authorized to connect (5)) when try to reconnect the service after restart application.