### PR TITLE
Allow specifying custom persistence on MqttAndroidClient

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttAndroidClient.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttAndroidClient.kt
@@ -36,7 +36,9 @@ import javax.net.ssl.TrustManagerFactory
  *  * disconnect
  *
  */
-class MqttAndroidClient(val context: Context, private val serverURI: String, private val clientId: String, ackType: Ack = Ack.AUTO_ACK) :
+class MqttAndroidClient @JvmOverloads constructor(
+    val context: Context, private val serverURI: String, private val clientId: String, ackType: Ack = Ack.AUTO_ACK,
+    private var persistence: MqttClientPersistence? = null) :
     BroadcastReceiver(), IMqttAsyncClient {
 
     // Listener for when the service is connected or disconnected
@@ -54,7 +56,6 @@ class MqttAndroidClient(val context: Context, private val serverURI: String, pri
     // An identifier for the underlying client connection, which we can pass to the service
     private var clientHandle: String? = null
     private var tokenNumber = 0
-    private var persistence: MqttClientPersistence? = null
     private var clientConnectOptions: MqttConnectOptions? = null
     private var connectToken: IMqttToken? = null
 
@@ -82,6 +83,7 @@ class MqttAndroidClient(val context: Context, private val serverURI: String, pri
      * @param clientId    specifies the name by which this connection should be identified to the server null then the default persistence
      * mechanism is used
      * @param ackType     how the application wishes to acknowledge a message has been processed.
+     * @param persistence specifies the persistence to use mechanism to use, or null to obtain a default.
      */
 
     /**


### PR DESCRIPTION
This change is to introduce the ability to construct an MqttAndroidClient with a specific persistence object, as was possible [here](https://github.com/eclipse/paho.mqtt.android/blob/3cb8af72f21b56ba72a6a6ddf3066d07d42f80b5/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java#L211).

I added it to the primary constructor with a default value of null, so that existing callers won't be impacted by having to pass it. I also added JvmOverloads annotation for Java callers to see constructor overloads.

This is a possible solution to #333.