### PR TITLE
Move namespace

### DIFF
--- a/basicSample/build.gradle
+++ b/basicSample/build.gradle
@@ -20,6 +20,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'info.mqtt.java.example'
 
 }
 

--- a/basicSample/src/main/AndroidManifest.xml
+++ b/basicSample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="info.mqtt.java.example"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
 

--- a/extendedSample/build.gradle
+++ b/extendedSample/build.gradle
@@ -24,6 +24,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'info.mqtt.android.extsample'
 
 }
 

--- a/extendedSample/src/main/AndroidManifest.xml
+++ b/extendedSample/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="info.mqtt.android.extsample"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/serviceLibrary/build.gradle
+++ b/serviceLibrary/build.gradle
@@ -35,7 +35,8 @@ android {
             }
         }
     }
-
+    namespace 'info.mqtt.android.service'
+    testNamespace 'info.mqtt.android.service.test'
 }
 
 dependencies {

--- a/serviceLibrary/src/androidTest/AndroidManifest.xml
+++ b/serviceLibrary/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="info.mqtt.android.service.test"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <!-- Mqtt Service -->

--- a/serviceLibrary/src/main/AndroidManifest.xml
+++ b/serviceLibrary/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="org.eclipse.paho.android.service"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
The library comes now with a new namespace
* `info.mqtt.android.service` instead of
* `org.eclipse.paho.android.service`