### PR TITLE
[Reconnect crash resolve(NullPointerException)]

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
@@ -164,11 +164,11 @@ internal class MqttConnection(
                 }
             } else {
                 alarmPingSender = AlarmPingSender(service)
+                setConnectingState(true)
                 myClient = MqttAsyncClient(serverURI, clientId, persistence, alarmPingSender)
                 //, null,	new AndroidHighResolutionTimer());
                 myClient!!.setCallback(this)
                 service.traceDebug("Do Real connect!")
-                setConnectingState(true)
                 myClient!!.connect(connectOptions, invocationContext, listener)
             }
         } catch (e: Exception) {


### PR DESCRIPTION
- Precondition: isAutomaticReconnect(ConnectOptoion) is true

- MqttConnection make MqttAsyncClient instance -> Network state changed(Connected) -> MqttConnection reconnect(synchronized fun) -> MqttConnection setConnectingState wait(synchronized fun) -> MqttAsyncClient reconnect -> MqttAsyncClient stopReconnectCycle fun -> MqttAsyncClient connOpts is null

Please check log below

Fatal Exception: java.lang.NullPointerException

> org.eclipse.paho.client.mqttv3.MqttAsyncClient.stopReconnectCycle (MqttAsyncClient.java:1451) org.eclipse.paho.client.mqttv3.MqttAsyncClient.reconnect (MqttAsyncClient.java:1404) info.mqtt.android.service.MqttConnection$reconnect$1.invokeSuspend (MqttConnection.kt:746) kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:30)
