### PR TITLE
Remove foreground notification when the service is started in foreground

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttService.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttService.kt
@@ -187,6 +187,7 @@ class MqttService : Service(), MqttTraceHandler {
 
     // callback id for making trace callbacks to the Activity needs to be set by the activity as appropriate
     private var traceCallbackId: String? = null
+    private var isForegroundStarted = false
 
     var isTraceEnabled = false
 
@@ -238,6 +239,7 @@ class MqttService : Service(), MqttTraceHandler {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val foregroundServiceNotification = intent?.getParcelableExtra<Notification>(MQTT_FOREGROUND_SERVICE_NOTIFICATION)
             if (foregroundServiceNotification != null) {
+                isForegroundStarted = true
                 startForeground(
                     intent.getIntExtra(MQTT_FOREGROUND_SERVICE_NOTIFICATION_ID, 1),
                     foregroundServiceNotification
@@ -320,6 +322,18 @@ class MqttService : Service(), MqttTraceHandler {
         val client = getConnection(clientHandle)
         client.close()
     }
+    /**
+     * Stop service, removing the notification if needed
+     */
+    private fun stopService(){
+        if (isForegroundStarted ) {
+            if  (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                stopForeground(Service.STOP_FOREGROUND_REMOVE)
+            else
+                stopForeground(true)
+        }
+        stopSelf()
+    }
 
     /**
      * Disconnect from the server
@@ -337,7 +351,7 @@ class MqttService : Service(), MqttTraceHandler {
         // the activity has finished using us, so we can stop the service
         // the activities are bound with BIND_AUTO_CREATE, so the service will
         // remain around until the last activity disconnects
-        stopSelf()
+        stopService()
     }
 
     /**
@@ -356,7 +370,7 @@ class MqttService : Service(), MqttTraceHandler {
         // the activity has finished using us, so we can stop the service
         // the activities are bound with BIND_AUTO_CREATE, so the service will
         // remain around until the last activity disconnects
-        stopSelf()
+        stopService()
     }
 
     /**

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttService.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttService.kt
@@ -322,12 +322,13 @@ class MqttService : Service(), MqttTraceHandler {
         val client = getConnection(clientHandle)
         client.close()
     }
+
     /**
      * Stop service, removing the notification if needed
      */
-    private fun stopService(){
-        if (isForegroundStarted ) {
-            if  (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+    private fun stopService() {
+        if (isForegroundStarted) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
                 stopForeground(Service.STOP_FOREGROUND_REMOVE)
             else
                 stopForeground(true)


### PR DESCRIPTION
Replace calling `stopSelf` with a new method that also removes the foreground service stuff