### PR TITLE
Fix for exact alarms not allowed

### DIFF
--- a/serviceLibrary/src/main/AndroidManifest.xml
+++ b/serviceLibrary/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <!-- <uses-permission android:name="android.permission.USE_EXACT_ALARM" /> this is only required for calendar apps -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -81,7 +81,20 @@ internal class AlarmPingSender(val service: MqttService) : MqttPingSender {
         Timber.d("Schedule next alarm at $nextAlarmInMilliseconds ms")
         val alarmManager = service.getSystemService(Service.ALARM_SERVICE) as AlarmManager
         pendingIntent?.let {
-            if (Build.VERSION.SDK_INT >= 23) {
+            //add check for android 13 and up
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                //check if we can scheduele exact alarms
+                if(alarmManager.canScheduleExactAlarms()) {
+                    Timber.d("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")
+                    alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
+                } else // it's up to the app to ask for permission so we schedule with a no exact but we do warn in the logs about it
+                {
+                    Timber.w("Not allowed to schedule exact alarms! using non exact alarm")
+                    Timber.w("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")
+                    alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
+                }
+            }
+            else if (Build.VERSION.SDK_INT >= 23) {
                 // In SDK 23 and above, dosing will prevent setExact, setExactAndAllowWhileIdle will force
                 // the device to run this task whilst dosing.
                 Timber.d("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -98,9 +98,10 @@ internal class AlarmPingSender(val service: MqttService) : MqttPingSender {
                 // the device to run this task whilst dosing.
                 Timber.d("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")
                 alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
-            } else
+            } else {
                 Timber.d("Alarm schedule using setExact, delay: $delayInMilliseconds")
-            alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
+                alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
+            }
         }
     }
 

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -82,9 +82,9 @@ internal class AlarmPingSender(val service: MqttService) : MqttPingSender {
         val alarmManager = service.getSystemService(Service.ALARM_SERVICE) as AlarmManager
         pendingIntent?.let {
             //add check for android 13 and up
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 //check if we can scheduele exact alarms
-                if(alarmManager.canScheduleExactAlarms()) {
+                if (alarmManager.canScheduleExactAlarms()) {
                     Timber.d("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")
                     alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
                 } else // it's up to the app to ask for permission so we schedule with a no exact but we do warn in the logs about it
@@ -93,8 +93,7 @@ internal class AlarmPingSender(val service: MqttService) : MqttPingSender {
                     Timber.w("Alarm schedule using setAndAllowWhileIdle, next: $delayInMilliseconds")
                     alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
                 }
-            }
-            else if (Build.VERSION.SDK_INT >= 23) {
+            } else if (Build.VERSION.SDK_INT >= 23) {
                 // In SDK 23 and above, dosing will prevent setExact, setExactAndAllowWhileIdle will force
                 // the device to run this task whilst dosing.
                 Timber.d("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -90,7 +90,7 @@ internal class AlarmPingSender(val service: MqttService) : MqttPingSender {
                 } else // it's up to the app to ask for permission so we schedule with a no exact but we do warn in the logs about it
                 {
                     Timber.w("Not allowed to schedule exact alarms! using non exact alarm")
-                    Timber.w("Alarm schedule using setExactAndAllowWhileIdle, next: $delayInMilliseconds")
+                    Timber.w("Alarm schedule using setAndAllowWhileIdle, next: $delayInMilliseconds")
                     alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextAlarmInMilliseconds, it)
                 }
             }


### PR DESCRIPTION
added a check if exact alarms are allowed to be schedeuled other wise put a warning in logs and use normasl schedule 

also removed use exact alarm as this is only allowed for calendar apps