### PR TITLE
Fix keepalive ping not sending

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -53,7 +53,7 @@ internal class AlarmPingSender(val service: MqttService) : MqttPingSender {
     override fun start() {
         val action = MqttServiceConstants.PING_SENDER + clientComms!!.client.clientId
         Timber.d("Register AlarmReceiver to MqttService$action")
-        ContextCompat.registerReceiver(service, alarmReceiver, IntentFilter(action), ContextCompat.RECEIVER_NOT_EXPORTED)
+        ContextCompat.registerReceiver(service, alarmReceiver, IntentFilter(action), ContextCompat.RECEIVER_EXPORTED)
         pendingIntent = PendingIntent.getBroadcast(service, 0, Intent(action), pendingIntentFlags)
         schedule(clientComms!!.keepAlive)
         hasStarted = true


### PR DESCRIPTION
For API level higher than 34 when using custom intent action registerReceiver must be RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED with package name when sending broadcast

You can see this problem in `basicSample`. No keepalive ping was sent so that client loses connection all the time and reconnects. I found this problem in my app and investigated the cause so I found it here

I tested is afterward it fixed the issue