### PR TITLE
Revert "Less strict mode detected violations"

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
@@ -364,10 +364,8 @@ internal class MqttConnection(
                 val message = MqttMessage(payload)
                 message.qos = qos.value
                 message.isRetained = retained
-                CoroutineScope(Dispatchers.IO).launch {
-                    sendToken = myClient!!.publish(topic, payload, qos.value, retained, invocationContext, listener)
-                    storeSendDetailsInMemory(topic, message, sendToken, invocationContext, activityToken)
-                }
+                sendToken = myClient!!.publish(topic, payload, qos.value, retained, invocationContext, listener)
+                storeSendDetailsInMemory(topic, message, sendToken, invocationContext, activityToken)
             } catch (e: Exception) {
                 handleException(resultBundle, e)
             }


### PR DESCRIPTION
This reverts commit 39e5ed4a5fe425d4baf6248cf582574e84656db2.

Why reverted?

The commit caused 2 problems: 

### Problem 1: 
run in coroutine, make the "client connected" pre-check might not valid anymore when it runs, therefore the underlying sendNoWait 'client connected' check not matched causing the following exception:

![image](https://github.com/hannesa2/paho.mqtt.android/assets/24354499/dd52821d-f59b-43a9-96af-0fdbcd4298c4)


### Problem2: 
run in coroutine, make the "sendToken" assignment-and-return invalid, it may always return null outside coroutine.

![image](https://github.com/hannesa2/paho.mqtt.android/assets/24354499/5f754b77-039f-41a9-9303-b5874a14929b)

