### PR TITLE
fix: changed the companion object to be able to keep multiple connect…

### DIFF
--- a/serviceLibrary/src/androidTest/assets/test.properties
+++ b/serviceLibrary/src/androidTest/assets/test.properties
@@ -1,6 +1,6 @@
 # This is the server URI which will be set in the constructor of an MQTT Client
 # The default is "tcp://<localhost>:1883" with <localhost> expressed in IPV4 dotted decimal notation
-SERVER_URI=tcp://broker.hivemq.com:1883
+SERVER_URI=tcp://broker.emqx.io:1883
 SERVER_SSL_URI=ssl://broker.hivemq.com:8883
 CLIENT_KEY_STORE=test.bks
 CLIENT_KEY_STORE_PASSWORD=mqtttest

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
@@ -165,7 +165,7 @@ internal class MqttConnection(
                     myClient!!.connect(connectOptions, invocationContext, listener)
                 }
             } else {
-                alarmPingSender = AlarmPingSender(service)
+                alarmPingSender = AlarmPingSender(service,clientId)
                 setConnectingState(true)
                 myClient = MqttAsyncClient(serverURI, clientId, persistence, alarmPingSender)
                 //, null,	new AndroidHighResolutionTimer());


### PR DESCRIPTION
A ping issue arose when multiple clients were connected. The AlarmPingSender's companion object only stored one ClientComm instance.  Consequently, when a new client initialized the AlarmPingSender, it overwrote the previously stored ClientComm. This meant the first client, and any subsequent clients before the last one, stopped receiving pings.

To resolve this, I implemented a map to store ClientComm instances, keyed by client ID.  This allows us to schedule separate ping jobs for each client, based on their individual keep-alive intervals.  This ensures each client receives pings according to its own configuration.