### PR TITLE
Multiple client ping

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttConnection.kt
@@ -165,7 +165,7 @@ internal class MqttConnection(
                     myClient!!.connect(connectOptions, invocationContext, listener)
                 }
             } else {
-                alarmPingSender = AlarmPingSender(service,clientId)
+                alarmPingSender = AlarmPingSender(service, clientId)
                 setConnectingState(true)
                 myClient = MqttAsyncClient(serverURI, clientId, persistence, alarmPingSender)
                 //, null,	new AndroidHighResolutionTimer());

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -38,12 +38,9 @@ internal class AlarmPingSender(val service: MqttService,
 
     override fun start() {
         Timber.d("Start ping job $id")
-            if (clientCommsMap.containsKey(id)) {
-                clientCommsMap[id]?.clientState?.let {
-                    schedule(clientCommsMap[id]!!.keepAlive)
-                } ?: Timber.e("FIXME: try to start ping schedule, but clientState null, not able to get keepAlive")
-            }
-        // add clientState null check to avoid ClientState.getKeepAlive() NPE(#358, #433)
+        clientCommsMap[id]?.clientState?.let {
+            schedule(clientCommsMap[id]!!.keepAlive)
+        } ?: Timber.e("FIXME: try to start ping schedule, but clientState null, not able to get keepAlive")
     }
 
 

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -2,7 +2,6 @@ package info.mqtt.android.service.ping
 
 import androidx.work.*
 import info.mqtt.android.service.MqttService
-import kotlinx.coroutines.sync.Mutex
 import org.eclipse.paho.client.mqttv3.MqttPingSender
 import org.eclipse.paho.client.mqttv3.internal.ClientComms
 import timber.log.Timber
@@ -26,13 +25,13 @@ internal class AlarmPingSender(val service: MqttService,val id: String) : MqttPi
 
 
     override fun init(comms: ClientComms) {
-        clientCommsMap[id] = comms;
-        Timber.w("Init ping job ${id}")
+        clientCommsMap[id] = comms
+        Timber.w("Init ping job $id")
 
     }
 
     override fun start() {
-        Timber.d("Start ping job ${id}")
+        Timber.d("Start ping job $id")
 
 
             if (clientCommsMap.containsKey(id)) {
@@ -41,25 +40,25 @@ internal class AlarmPingSender(val service: MqttService,val id: String) : MqttPi
 
     }
 
-    private fun getName(): String = "$id"
+    private fun getName(): String = id
 
     override fun stop() {
-        workManager.cancelUniqueWork("PINGJOB_${getName()}")
-        //remove the clientComs from the map
+        workManager.cancelUniqueWork("PING_JOB_${getName()}")
+        //remove the clientComms from the map
         Timber.d("Stop ping job ${getName()}")
         clientCommsMap.remove(id)
     }
 
     override fun schedule(delayInMilliseconds: Long) {
 
-        val name = getName();
+        val name = getName()
         Timber.d("${name}: Schedule next alarm at ${System.currentTimeMillis() + delayInMilliseconds} ")
 
         val d: Data = Data.Builder().putString("id", name)
 
             .build()
 
-      var op =  workManager.enqueueUniqueWork(
+       workManager.enqueueUniqueWork(
             "PING_JOB_$name",
             ExistingWorkPolicy.REPLACE,
             OneTimeWorkRequest
@@ -71,7 +70,6 @@ internal class AlarmPingSender(val service: MqttService,val id: String) : MqttPi
     }
 
     companion object {
-        private const val PING_JOB = "PING_JOB"
         internal var clientCommsMap: ConcurrentMap<String,ClientComms> =  ConcurrentHashMap()
 
     }

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -8,7 +8,6 @@ import org.eclipse.paho.client.mqttv3.MqttPingSender
 import org.eclipse.paho.client.mqttv3.internal.ClientComms
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -23,8 +22,7 @@ import java.util.concurrent.TimeUnit
  *
  * @see MqttPingSender
  */
-internal class AlarmPingSender(val service: MqttService,val id: String,
-                               private val pingLogging: Boolean = false, private val keepPingRecords: Int = 1000) : MqttPingSender {
+internal class AlarmPingSender(val service: MqttService, val id: String, private val pingLogging: Boolean = false, private val keepPingRecords: Int = 1000) : MqttPingSender {
 
 
     private val workManager = WorkManager.getInstance(service)
@@ -37,16 +35,12 @@ internal class AlarmPingSender(val service: MqttService,val id: String,
 
     override fun start() {
         Timber.d("Start ping job $id")
-
-
             if (clientCommsMap.containsKey(id)) {
                 clientCommsMap[id]?.clientState?.let {
                     schedule(clientCommsMap[id]!!.keepAlive)
                 } ?: Timber.e("FIXME: try to start ping schedule, but clientState null, not able to get keepAlive")
             }
-
-        // add clientState null check to avoid ClientState.getKeepAlive() NPE(#358,#433)
-
+        // add clientState null check to avoid ClientState.getKeepAlive() NPE(#358, #433)
     }
 
 
@@ -54,34 +48,32 @@ internal class AlarmPingSender(val service: MqttService,val id: String,
     override fun stop() {
         //remove the clientComms from the map
         Timber.d("Stop ping job $id")
-        workManager.cancelUniqueWork("$AlarmPingSender.PING_JOB_$id")
-        clientCommsMap.remove(id);
+        workManager.cancelUniqueWork("${PING_JOB}_$id")
+        clientCommsMap.remove(id)
     }
 
     override fun schedule(delayInMilliseconds: Long) {
-
-
         Timber.d("$id: Schedule next alarm at ${sdf.format(Date(System.currentTimeMillis() + delayInMilliseconds))}")
 
         val pingWork = OneTimeWorkRequest.Builder(PingWorker::class.java)
         val data = Data.Builder()
         data.putBoolean("logging", pingLogging)
         data.putInt("keepRecordCount", keepPingRecords)
-        data.putString("id",id)
+        data.putString("id", id)
 
         pingWork
             .setInitialDelay(delayInMilliseconds, TimeUnit.MILLISECONDS)
             .setInputData(data.build())
 
         workManager.enqueueUniqueWork(
-             "$AlarmPingSender.PING_JOB_$id",
+            "${PING_JOB}_$id",
             ExistingWorkPolicy.REPLACE,
             pingWork.build()
         )
     }
 
     companion object {
-        internal var clientCommsMap: ConcurrentHashMap<String,ClientComms> = ConcurrentHashMap()
+        internal var clientCommsMap: ConcurrentHashMap<String, ClientComms> = ConcurrentHashMap()
 
         private const val PING_JOB = "PING_JOB"
 

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -22,7 +22,10 @@ import java.util.concurrent.TimeUnit
  *
  * @see MqttPingSender
  */
-internal class AlarmPingSender(val service: MqttService, val id: String, private val pingLogging: Boolean = false, private val keepPingRecords: Int = 1000) : MqttPingSender {
+internal class AlarmPingSender(val service: MqttService,
+                               val id: String,
+                               private val pingLogging: Boolean = false,
+                               private val keepPingRecords: Int = 1000) : MqttPingSender {
 
 
     private val workManager = WorkManager.getInstance(service)

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
@@ -3,10 +3,13 @@ package info.mqtt.android.service.ping
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import info.mqtt.android.service.ping.AlarmPingSender.Companion.sdf
+import info.mqtt.android.service.room.entity.PingEntity
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.eclipse.paho.client.mqttv3.IMqttActionListener
 import org.eclipse.paho.client.mqttv3.IMqttToken
 import timber.log.Timber
+import java.util.Date
 import kotlin.coroutines.resume
 
 class PingWorker(context: Context, workerParams: WorkerParameters) :
@@ -14,34 +17,64 @@ class PingWorker(context: Context, workerParams: WorkerParameters) :
 
     override suspend fun doWork(): Result =
         suspendCancellableCoroutine { continuation ->
+
+            val logging = inputData.getBoolean(LOGGING, false)
+            val keepRecords = inputData.getInt(KEEP_RECORDS_COUNT, 1000)
             val key = this.inputData.getString("id");
-            Timber.d("${key} Sending Ping at: ${System.currentTimeMillis()}")
+            Timber.d("$key Sending Ping at: ${sdf.format(Date(System.currentTimeMillis()))}")
 
             //check if id is not null
             if(key == null) {
+                Timber.e("connection id in ping worker is null!");
                 continuation.resume(Result.failure())
                 return@suspendCancellableCoroutine
             }
 
             //check if there is a clients comm asociated with the key
             if(!AlarmPingSender.clientCommsMap.containsKey(key)) {
+                Timber.e("client comm doesnt exist anymore: $key");
                 continuation.resume(Result.failure())
                 return@suspendCancellableCoroutine
             }
 
-
             AlarmPingSender.clientCommsMap[key]?.checkForActivity(object : IMqttActionListener {
                 override fun onSuccess(asyncActionToken: IMqttToken?) {
-                    Timber.d("$key Success.")
+                    Timber.d("$key Ping Success ${asyncActionToken?.client?.clientId}")
+                    if (logging) {
+                        val pingMQ = PingEntity(
+                            System.currentTimeMillis(),
+                            asyncActionToken?.client?.clientId,
+                            asyncActionToken?.client?.serverURI,
+                            true
+                        )
+                        AlarmPingSender.messageDatabase?.pingDao()?.insert(pingMQ)
+                        AlarmPingSender.messageDatabase?.pingDao()?.removeOldData(keepRecords)
+                    }
                     continuation.resume(Result.success())
                 }
 
                 override fun onFailure(asyncActionToken: IMqttToken?, exception: Throwable?) {
-                    Timber.e("$key Failure $exception")
+                    Timber.e("$key Ping Failure $exception ${asyncActionToken?.client?.clientId}")
+                    if (logging) {
+                        val pingMQ = PingEntity(
+                            System.currentTimeMillis(),
+                            asyncActionToken?.client?.clientId,
+                            asyncActionToken?.client?.serverURI,
+                            false,
+                            exception?.message
+                        )
+                        AlarmPingSender.messageDatabase?.pingDao()?.insert(pingMQ)
+                        AlarmPingSender.messageDatabase?.pingDao()?.removeOldData(keepRecords)
+                    }
                     continuation.resume(Result.failure())
                 }
             }) ?: kotlin.run {
                 continuation.resume(Result.failure())
             }
         }
+
+    companion object {
+        const val LOGGING = "logging"
+        const val KEEP_RECORDS_COUNT = "keepCount"
+    }
 }

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
@@ -3,60 +3,45 @@ package info.mqtt.android.service.ping
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import info.mqtt.android.service.ping.AlarmPingSender.Companion.sdf
-import info.mqtt.android.service.room.entity.PingEntity
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.eclipse.paho.client.mqttv3.IMqttActionListener
 import org.eclipse.paho.client.mqttv3.IMqttToken
 import timber.log.Timber
-import java.util.Date
 import kotlin.coroutines.resume
 
 class PingWorker(context: Context, workerParams: WorkerParameters) :
     CoroutineWorker(context, workerParams) {
+
     override suspend fun doWork(): Result =
         suspendCancellableCoroutine { continuation ->
-            Timber.d("Sending Ping at: ${sdf.format(Date(System.currentTimeMillis()))}")
-            val logging = inputData.getBoolean(LOGGING, false)
-            val keepRecords = inputData.getInt(KEEP_RECORDS_COUNT, 1000)
-            AlarmPingSender.clientComms?.checkForActivity(object : IMqttActionListener {
+            val key = this.inputData.getString("id");
+            Timber.d("${key} Sending Ping at: ${System.currentTimeMillis()}")
+
+            //check if id is not null
+            if(key == null) {
+                continuation.resume(Result.failure())
+                return@suspendCancellableCoroutine
+            }
+
+            //check if there is a clients comm asociated with the key
+            if(!AlarmPingSender.clientCommsMap.containsKey(key)) {
+                continuation.resume(Result.failure())
+                return@suspendCancellableCoroutine
+            }
+
+
+            AlarmPingSender.clientCommsMap[key]?.checkForActivity(object : IMqttActionListener {
                 override fun onSuccess(asyncActionToken: IMqttToken?) {
-                    Timber.d("Success ${asyncActionToken?.client?.clientId}")
-                    if (logging) {
-                        val pingMQ = PingEntity(
-                            System.currentTimeMillis(),
-                            asyncActionToken?.client?.clientId,
-                            asyncActionToken?.client?.serverURI,
-                            true
-                        )
-                        AlarmPingSender.messageDatabase?.pingDao()?.insert(pingMQ)
-                        AlarmPingSender.messageDatabase?.pingDao()?.removeOldData(keepRecords)
-                    }
+                    Timber.d("$key Success.")
                     continuation.resume(Result.success())
                 }
 
                 override fun onFailure(asyncActionToken: IMqttToken?, exception: Throwable?) {
-                    Timber.e("Failure $exception ${asyncActionToken?.client?.clientId}")
-                    if (logging) {
-                        val pingMQ = PingEntity(
-                            System.currentTimeMillis(),
-                            asyncActionToken?.client?.clientId,
-                            asyncActionToken?.client?.serverURI,
-                            false,
-                            exception?.message
-                        )
-                        AlarmPingSender.messageDatabase?.pingDao()?.insert(pingMQ)
-                        AlarmPingSender.messageDatabase?.pingDao()?.removeOldData(keepRecords)
-                    }
+                    Timber.e("$key Failure $exception")
                     continuation.resume(Result.failure())
                 }
             }) ?: kotlin.run {
                 continuation.resume(Result.failure())
             }
         }
-
-    companion object {
-        const val LOGGING = "logging"
-        const val KEEP_RECORDS_COUNT = "keepCount"
-    }
 }

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
@@ -20,19 +20,19 @@ class PingWorker(context: Context, workerParams: WorkerParameters) :
 
             val logging = inputData.getBoolean(LOGGING, false)
             val keepRecords = inputData.getInt(KEEP_RECORDS_COUNT, 1000)
-            val key = this.inputData.getString("id");
+            val key = this.inputData.getString("id")
             Timber.d("$key Sending Ping at: ${sdf.format(Date(System.currentTimeMillis()))}")
 
             //check if id is not null
-            if(key == null) {
-                Timber.e("connection id in ping worker is null!");
+            if (key == null) {
+                Timber.e("connection id in ping worker is null!")
                 continuation.resume(Result.failure())
                 return@suspendCancellableCoroutine
             }
 
             //check if there is a clients comm asociated with the key
-            if(!AlarmPingSender.clientCommsMap.containsKey(key)) {
-                Timber.e("client comm doesnt exist anymore: $key");
+            if (!AlarmPingSender.clientCommsMap.containsKey(key)) {
+                Timber.e("client comm doesn't exist anymore: $key")
                 continuation.resume(Result.failure())
                 return@suspendCancellableCoroutine
             }


### PR DESCRIPTION
A ping issue arose when multiple clients were connected. The AlarmPingSender's companion object only stored one ClientComm instance. Consequently, when a new client initialized the AlarmPingSender, it overwrote the previously stored ClientComm. This meant the first client, and any subsequent clients before the last one, stopped receiving pings.

To resolve this, I implemented a map to store ClientComm instances, keyed by client ID. This allows us to schedule separate ping jobs for each client, based on their individual keep-alive intervals. This ensures each client receives pings according to its own configuration.