### PR TITLE
Keep client coms on stop other wise a next start won't work

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -43,13 +43,10 @@ internal class AlarmPingSender(val service: MqttService,
         } ?: Timber.e("FIXME: try to start ping schedule, but clientState null, not able to get keepAlive")
     }
 
-
-
     override fun stop() {
         //remove the clientComms from the map
         Timber.d("Stop ping job $id")
         workManager.cancelUniqueWork("${PING_JOB}_$id")
-        clientCommsMap.remove(id)
     }
 
     override fun schedule(delayInMilliseconds: Long) {


### PR DESCRIPTION
after that the stop is called the start can be recalled afterwards without that the init is called and then the ping job can't be started so removed the delete