### PR TITLE
Avoid publish warning

### DIFF
--- a/serviceLibrary/build.gradle.kts
+++ b/serviceLibrary/build.gradle.kts
@@ -63,6 +63,9 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 dependencies {
@@ -83,14 +86,4 @@ dependencies {
     androidTestUtil("androidx.test.services:test-services:1.5.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.test:rules:1.6.1")
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("maven") {
-                from(components["release"])
-            }
-        }
-    }
 }


### PR DESCRIPTION
w: ⚠️ Android Publication 'maven' Misconfigured for Variant 'release' Android Publication 'maven' for variant 'release' was not configured properly:

To avoid this warning, please create and configure Android publication variant with name 'release'. Example:
```
android {
    publishing {
        singleVariant("release") {}
    }
}
```