### PR TITLE
Ping fix that happens before last ping

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -9,9 +9,11 @@ import org.eclipse.paho.client.mqttv3.internal.ClientComms
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
 import java.text.SimpleDateFormat
+import java.time.Instant
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+
 
 
 /**
@@ -53,32 +55,25 @@ internal class AlarmPingSender(
     override fun schedule(delayInMilliseconds: Long) {
         Timber.d("$id: Schedule next alarm at ${sdf.format(Date(System.currentTimeMillis() + delayInMilliseconds))}")
 
-        // Check if work is already scheduled with this ID
-        val workInfo = workManager.getWorkInfosForUniqueWork("${PING_JOB}_$id").get()
+        val pingWork = OneTimeWorkRequest.Builder(PingWorker::class.java)
+        val data = Data.Builder()
+        data.putBoolean("logging", pingLogging)
+        data.putInt("keepRecordCount", keepPingRecords)
+        data.putString("id", id)
 
-        // Only schedule if no work exists or all existing work is finished/cancelled
-        if (workInfo.isEmpty() || workInfo.all { it.state.isFinished }) {
-            val pingWork = OneTimeWorkRequest.Builder(PingWorker::class.java)
-            val data = Data.Builder()
-            data.putBoolean("logging", pingLogging)
-            data.putInt("keepRecordCount", keepPingRecords)
-            data.putString("id", id)
+        pingWork
+            .setInitialDelay(delayInMilliseconds, TimeUnit.MILLISECONDS)
+            .setInputData(data.build())
 
-            pingWork
-                .setInitialDelay(delayInMilliseconds, TimeUnit.MILLISECONDS)
-//                .setInitialDelay(30, TimeUnit.SECONDS)
-                .setInputData(data.build())
+        // we add the currentTimeMillis to keep the prev job running
+        val uniqueWorkName = "${PING_JOB}_${id}_${System.currentTimeMillis()}"
 
-            workManager.enqueueUniqueWork(
-                "${PING_JOB}_$id",
-                ExistingWorkPolicy.REPLACE,
-                pingWork.build()
-            )
-
-            Timber.d("$id: Successfully scheduled new ping job")
-        } else {
-            Timber.w("$id: I GOT YOU Ping job already scheduled, skipping")
-        }
+        workManager.enqueueUniqueWork(
+            uniqueWorkName,
+            ExistingWorkPolicy.REPLACE,
+            pingWork.build()
+        )
+        Timber.d("$id: Successfully scheduled new ping job")
     }
 
     companion object {

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -49,7 +49,7 @@ internal class AlarmPingSender(
     override fun stop() {
         //remove the clientComms from the map
         Timber.d("Stop ping job $id")
-        workManager.cancelUniqueWork("${PING_JOB}_$id")
+        workManager.cancelAllWorkByTag("${PING_JOB}_$id")
     }
 
     override fun schedule(delayInMilliseconds: Long) {
@@ -64,6 +64,7 @@ internal class AlarmPingSender(
         pingWork
             .setInitialDelay(delayInMilliseconds, TimeUnit.MILLISECONDS)
             .setInputData(data.build())
+            .addTag("${PING_JOB}_$id") 
 
         // we add the currentTimeMillis to keep the prev job running
         val uniqueWorkName = "${PING_JOB}_${id}_${System.currentTimeMillis()}"
@@ -73,6 +74,9 @@ internal class AlarmPingSender(
             ExistingWorkPolicy.REPLACE,
             pingWork.build()
         )
+
+
+
         Timber.d("$id: Successfully scheduled new ping job")
     }
 

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/AlarmPingSender.kt
@@ -9,7 +9,6 @@ import org.eclipse.paho.client.mqttv3.internal.ClientComms
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
 import java.text.SimpleDateFormat
-import java.time.Instant
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -64,7 +63,7 @@ internal class AlarmPingSender(
         pingWork
             .setInitialDelay(delayInMilliseconds, TimeUnit.MILLISECONDS)
             .setInputData(data.build())
-            .addTag("${PING_JOB}_$id") 
+            .addTag("${PING_JOB}_$id")
 
         // we add the currentTimeMillis to keep the prev job running
         val uniqueWorkName = "${PING_JOB}_${id}_${System.currentTimeMillis()}"

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/ping/PingWorker.kt
@@ -69,7 +69,9 @@ class PingWorker(context: Context, workerParams: WorkerParameters) :
                     continuation.resume(Result.failure())
                 }
             }) ?: kotlin.run {
-                continuation.resume(Result.failure())
+                // when token is null doesn't always mean a failure sometimes there wasn't a need
+                // send a ping request yet
+                continuation.resume(Result.success())
             }
         }
 


### PR DESCRIPTION
instead of not replacing the ping job we now add a new job with a unique id, but added a tag to all the jobs so we can still cancel all of them if the Stop is called, so now a new ping is schedueled and the last one can finish in the mean time.