### PR TITLE
Revert "Cleanup MQTTAndroidClient"

### DIFF
--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttAndroidClient.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttAndroidClient.kt
@@ -42,7 +42,7 @@ import javax.net.ssl.TrustManagerFactory
  *  * disconnect
  *
  */
-class MqttAndroidClient(
+class MqttAndroidClient @JvmOverloads constructor(
     val context: Context, private val serverURI: String, private val clientId: String, ackType: Ack = Ack.AUTO_ACK,
     private var persistence: MqttClientPersistence? = null,
     private val pingLogging: Boolean = false,


### PR DESCRIPTION
This reverts commit 269d013aa068b5d90ca4d5e64c4ced353cb6675e.

Add back the @JvmOverloads annotation to maintain backward compatibility with older versions, at least for constructors using default parameters.