### PR TITLE
Remove publish warning

### DIFF
--- a/serviceLibrary/build.gradle.kts
+++ b/serviceLibrary/build.gradle.kts
@@ -63,6 +63,9 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 dependencies {


### PR DESCRIPTION
w: Android Publication 'maven' Misconfigured for Variant 'release' Android Publication 'maven' for variant 'release' was not configured properly:

To avoid this warning, please create and configure Android publication variant with name 'release'. Example:
```
android {
    publishing {
        singleVariant("release") {}
    }
}
```