### PR TITLE
Replaced org.eclipse.paho.client.mqttv3 with hannesa2 paho.mqtt.java on 3.x

### DIFF
--- a/serviceLibrary/build.gradle
+++ b/serviceLibrary/build.gradle
@@ -48,7 +48,7 @@ android {
 }
 
 dependencies {
-    api "org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5"
+    api "com.github.hannesa2:paho.mqtt.java:1.2.6-beta6"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "androidx.core:core-ktx:1.10.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1"

--- a/serviceLibrary/src/main/java/info/mqtt/android/service/MqttAndroidClient.kt
+++ b/serviceLibrary/src/main/java/info/mqtt/android/service/MqttAndroidClient.kt
@@ -1237,6 +1237,11 @@ class MqttAndroidClient @JvmOverloads constructor(
         throw UnsupportedOperationException()
     }
 
+    @Throws(MqttException::class)
+    override fun disconnectForcibly(quiesceTimeout: Long, disconnectTimeout: Long, p2: Boolean) {
+        throw UnsupportedOperationException()
+    }
+
     /**
      * Unregister receiver which receives intent from MqttService avoids
      * IntentReceiver leaks.


### PR DESCRIPTION
Replaced    "org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5 with com.github.hannesa2:paho.mqtt.java:1.2.6-beta6
Override disconnectForcibly in MqttAndroidClient